### PR TITLE
Add printInAir feature to allow placing blocks without support

### DIFF
--- a/src/main/java/me/aleksilassila/litematica/printer/config/Configs.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/config/Configs.java
@@ -20,6 +20,7 @@ public class Configs {
     public static final ConfigBoolean REPLACE_FLUIDS_SOURCE_BLOCKS = new ConfigBoolean("replaceFluidSourceBlocks", true).apply(GENERIC_KEY);
     public static final ConfigBoolean STRIP_LOGS = new ConfigBoolean("stripLogs", true).apply(GENERIC_KEY);
     public static final ConfigBoolean INTERACT_BLOCKS = new ConfigBoolean("interactBlocks", true).apply(GENERIC_KEY);
+    public static final ConfigBoolean PRINT_IN_AIR = new ConfigBoolean("printInAir", false).apply(GENERIC_KEY);
 
     public static ImmutableList<IConfigBase> getConfigList() {
         List<IConfigBase> list = new java.util.ArrayList<>(fi.dy.masa.litematica.config.Configs.Generic.OPTIONS);
@@ -30,6 +31,7 @@ public class Configs {
         list.add(REPLACE_FLUIDS_SOURCE_BLOCKS);
         list.add(STRIP_LOGS);
         list.add(INTERACT_BLOCKS);
+        list.add(PRINT_IN_AIR);
 
         return ImmutableList.copyOf(list);
     }

--- a/src/main/java/me/aleksilassila/litematica/printer/guides/placement/GeneralPlacementGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guides/placement/GeneralPlacementGuide.java
@@ -2,6 +2,7 @@ package me.aleksilassila.litematica.printer.guides.placement;
 
 import me.aleksilassila.litematica.printer.Printer;
 import me.aleksilassila.litematica.printer.SchematicBlockState;
+import me.aleksilassila.litematica.printer.config.Configs;
 import me.aleksilassila.litematica.printer.implementation.PrinterPlacementContext;
 import net.minecraft.block.SlabBlock;
 import net.minecraft.block.enums.SlabType;
@@ -47,7 +48,7 @@ public class GeneralPlacementGuide extends PlacementGuide {
     }
 
     private Optional<Direction> getValidSide(SchematicBlockState state) {
-        boolean printInAir = false; // LitematicaMixinMod.PRINT_IN_AIR.getBooleanValue();
+        boolean printInAir = Configs.PRINT_IN_AIR.getBooleanValue();
 
         List<Direction> sides = getPossibleSides();
 
@@ -55,22 +56,23 @@ public class GeneralPlacementGuide extends PlacementGuide {
             return Optional.empty();
         }
 
+        if (printInAir && !getRequiresSupport()) {
+            // When printInAir is enabled, we can place directly without support
+            return Optional.of(Direction.UP); // Use any direction as we'll target the position directly
+        }
+
         List<Direction> validSides = new ArrayList<>();
         for (Direction side : sides) {
-            if (printInAir && !getRequiresSupport()) {
-                return Optional.of(side);
-            } else {
-                SchematicBlockState neighborState = state.offset(side);
+            SchematicBlockState neighborState = state.offset(side);
 
-                if (getProperty(neighborState.currentState, SlabBlock.TYPE).orElse(null) == SlabType.DOUBLE) {
-                    validSides.add(side);
-                    continue;
-                }
-
-                if (canBeClicked(neighborState.world, neighborState.blockPos) && // Handle unclickable grass for example
-                        !neighborState.currentState.isReplaceable())
-                    validSides.add(side);
+            if (getProperty(neighborState.currentState, SlabBlock.TYPE).orElse(null) == SlabType.DOUBLE) {
+                validSides.add(side);
+                continue;
             }
+
+            if (canBeClicked(neighborState.world, neighborState.blockPos) && // Handle unclickable grass for example
+                    !neighborState.currentState.isReplaceable())
+                validSides.add(side);
         }
 
         for (Direction validSide : validSides) {
@@ -93,6 +95,13 @@ public class GeneralPlacementGuide extends PlacementGuide {
     }
 
     private Optional<Vec3d> getHitVector(SchematicBlockState state) {
+        boolean printInAir = Configs.PRINT_IN_AIR.getBooleanValue();
+
+        if (printInAir && !getRequiresSupport()) {
+            // For air placement, target the center of the target block position
+            return Optional.of(Vec3d.ofCenter(state.blockPos));
+        }
+
         return getValidSide(state).map(side -> Vec3d.ofCenter(state.blockPos)
                 .add(Vec3d.of(side.getVector()).multiply(0.5))
                 .add(getHitModifier(side)));
@@ -112,8 +121,17 @@ public class GeneralPlacementGuide extends PlacementGuide {
             Optional<Direction> lookDirection = getLookDirection();
             boolean requiresShift = getUseShift(state);
 
-            BlockHitResult blockHitResult = new BlockHitResult(hitVec.get(), validSide.get().getOpposite(),
-                    state.blockPos.offset(validSide.get()), false);
+            boolean printInAir = Configs.PRINT_IN_AIR.getBooleanValue();
+            BlockHitResult blockHitResult;
+
+            if (printInAir && !getRequiresSupport()) {
+                // For air placement, target the block position directly with a reasonable side
+                // Using UP direction as default to place block normally
+                blockHitResult = new BlockHitResult(hitVec.get(), Direction.DOWN, state.blockPos, false);
+            } else {
+                blockHitResult = new BlockHitResult(hitVec.get(), validSide.get().getOpposite(),
+                        state.blockPos.offset(validSide.get()), false);
+            }
 
             return new PrinterPlacementContext(player, blockHitResult, requiredItem.get(), requiredSlot,
                     lookDirection.orElse(null), requiresShift);

--- a/src/main/java/me/aleksilassila/litematica/printer/guides/placement/GuesserGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guides/placement/GuesserGuide.java
@@ -54,6 +54,32 @@ public class GuesserGuide extends GeneralPlacementGuide {
         if (contextCache != null && !Configs.PRINT_DEBUG.getBooleanValue())
             return contextCache;
 
+        // First, try air placement if enabled
+        boolean printInAir = Configs.PRINT_IN_AIR.getBooleanValue();
+        if (printInAir && !getRequiresSupport()) {
+            ItemStack requiredItem = getRequiredItem(player).orElse(ItemStack.EMPTY);
+            int slot = getRequiredItemStackSlot(player);
+
+            if (slot != -1) {
+                // Try different directions to find a successful placement
+                for (Direction side : directionsToTry) {
+                    Vec3d hitVec = Vec3d.ofCenter(state.blockPos);
+                    BlockHitResult hitResult = new BlockHitResult(hitVec, side.getOpposite(), state.blockPos, false);
+
+                    boolean requiresShift = getRequiresExplicitShift() || isInteractive(state.world.getBlockState(state.blockPos.offset(side.getOpposite())).getBlock());
+                    PrinterPlacementContext context = new PrinterPlacementContext(player, hitResult, requiredItem, slot, null, requiresShift);
+                    BlockState result = getRequiredItemAsBlock(player)
+                            .orElse(targetState.getBlock())
+                            .getPlacementState(context);
+
+                    if (result != null && (statesEqual(result, targetState) || correctChestPlacement(targetState, result))) {
+                        contextCache = context;
+                        return context;
+                    }
+                }
+            }
+        }
+
         ItemStack requiredItem = getRequiredItem(player).orElse(ItemStack.EMPTY);
         int slot = getRequiredItemStackSlot(player);
 

--- a/src/main/resources/assets/litematica-printer/lang/en_us.json
+++ b/src/main/resources/assets/litematica-printer/lang/en_us.json
@@ -6,6 +6,7 @@
     "litematica-printer.config.generic.name.replaceFluidSourceBlocks": "replaceFluidSourceBlocks",
     "litematica-printer.config.generic.name.stripLogs": "stripLogs",
     "litematica-printer.config.generic.name.interactBlocks": "interactBlocks",
+    "litematica-printer.config.generic.name.printInAir": "printInAir",
 
     "litematica-printer.config.generic.prettyName.printingInterval": "Printing Interval",
     "litematica-printer.config.generic.prettyName.printingRange": "Printing Range",
@@ -14,6 +15,7 @@
     "litematica-printer.config.generic.prettyName.replaceFluidSourceBlocks": "Replace Fluid Source Blocks",
     "litematica-printer.config.generic.prettyName.stripLogs": "Strip Logs",
     "litematica-printer.config.generic.prettyName.interactBlocks": "Interact Blocks",
+    "litematica-printer.config.generic.prettyName.printInAir": "Print in Air",
 
     "litematica-printer.config.generic.comment.printingInterval": "Printing interval. Lower values mean faster printing speed.\nIf the printer creates \"ghost blocks\" or blocks are facing the wrong way, raise this value.",
     "litematica-printer.config.generic.comment.printingRange": "Printing block place range\nLower values are recommended for servers.",
@@ -22,6 +24,7 @@
     "litematica-printer.config.generic.comment.replaceFluidSourceBlocks": "Whether or not fluid source blocks should be replaced by the printer.",
     "litematica-printer.config.generic.comment.stripLogs": "Whether or not the printer should use normal logs if stripped\nversions are not available and then strip them with an axe.",
     "litematica-printer.config.generic.comment.interactBlocks": "Whether or not the printer should set block states.",
+    "litematica-printer.config.generic.comment.printInAir": "Allow blocks to be placed in mid-air without requiring support blocks underneath.",
 
     "litematica-printer.config.hotkeys.name.print": "print",
     "litematica-printer.config.hotkeys.name.togglePrintingMode": "togglePrintingMode",

--- a/src/main/resources/assets/litematica-printer/lang/es_es.json
+++ b/src/main/resources/assets/litematica-printer/lang/es_es.json
@@ -1,5 +1,6 @@
 {
     "litematica-printer.config.generic.comment.interactBlocks": "Si la impresora debe establecer o no estados de bloque.",
+    "litematica-printer.config.generic.comment.printInAir": "Permitir que los bloques se coloquen en el aire sin necesidad de bloques de soporte debajo.",
     "litematica-printer.config.generic.comment.printingDebug": "Habilita el registro de depuración para la impresión.",
     "litematica-printer.config.generic.comment.printingInterval": "Intervalo de impresión. Los valores más bajos indican una mayor velocidad de impresión.\nSi la impresora crea \"Bloques fantasma\" o los bloques están orientados en la dirección incorrecta, aumente este valor.",
     "litematica-printer.config.generic.comment.printingMode": "Selección cargada de creación automática/impresión.\nTenga en cuenta que algunos servidores y complementos antitrampas no permiten la impresión.",
@@ -13,6 +14,7 @@
     "litematica-printer.config.generic.name.printingRange": "Rango de impresión",
     "litematica-printer.config.generic.name.replaceFluidSourceBlocks": "Reemplazar los bloques de fuente de fluido",
     "litematica-printer.config.generic.name.stripLogs": "Registros de corteza",
+    "litematica-printer.config.generic.name.printInAir": "Imprimir en el aire",
     "litematica-printer.config.generic.prettyName.interactBlocks": "Bloques interactivos",
     "litematica-printer.config.generic.prettyName.printingDebug": "Depuración de impresión",
     "litematica-printer.config.generic.prettyName.printingInterval": "Intervalo de impresión",
@@ -20,6 +22,7 @@
     "litematica-printer.config.generic.prettyName.printingRange": "Gama de impresión",
     "litematica-printer.config.generic.prettyName.replaceFluidSourceBlocks": "Reemplazar los bloques de fuente de fluido",
     "litematica-printer.config.generic.prettyName.stripLogs": "Registro de corteza",
+    "litematica-printer.config.generic.prettyName.printInAir": "Imprimir en el aire",
     "litematica-printer.config.hotkeys.comment.print": "Imprime mientras se presiona",
     "litematica-printer.config.hotkeys.comment.togglePrintingMode": "Permite alternar rápidamente entre habilitado y desactivado del modo de impresión",
     "litematica-printer.config.hotkeys.name.print": "Imprimir",

--- a/src/main/resources/assets/litematica-printer/lang/ko_kr.json
+++ b/src/main/resources/assets/litematica-printer/lang/ko_kr.json
@@ -1,5 +1,6 @@
 {
     "litematica-printer.config.generic.comment.interactBlocks": "프린터가 블록 상태를 설정해야 하는지 여부입니다.",
+    "litematica-printer.config.generic.comment.printInAir": "하부에 지지 블록 없이 공중에 블록을 설치할 수 있습니다.",
     "litematica-printer.config.generic.comment.printingDebug": "프린팅을 위한 디버그 로그 기록을 활성화합니다.",
     "litematica-printer.config.generic.comment.printingInterval": "프린트 간격입니다. 값이 낮을수록 프린트 속도가 빨라집니다.\n만약 프린트 중에 \"고스트 블록\"이 생기거나 블록의 방향이 잘못 설치된다면 값을 증가시키세요.",
     "litematica-printer.config.generic.comment.printingMode": "불러온 선택을 자동 건축 / 프린트 합니다.\n일부 서버와 안티치트 플러그인은 프린트를 금지할 수 있다는 것에 주의하세요.",
@@ -13,6 +14,7 @@
     "litematica-printer.config.generic.name.printingRange": "프린트 범위",
     "litematica-printer.config.generic.name.replaceFluidSourceBlocks": "유체 원천 블록 교체",
     "litematica-printer.config.generic.name.stripLogs": "원목 벗기기",
+    "litematica-printer.config.generic.name.printInAir": "공중에 프린트",
     "litematica-printer.config.generic.prettyName.interactBlocks": "블록 상호 작용",
     "litematica-printer.config.generic.prettyName.printingDebug": "프린트 디버그",
     "litematica-printer.config.generic.prettyName.printingInterval": "프린트 간격",
@@ -20,6 +22,7 @@
     "litematica-printer.config.generic.prettyName.printingRange": "프린트 범위",
     "litematica-printer.config.generic.prettyName.replaceFluidSourceBlocks": "유체 원천 블록 교체",
     "litematica-printer.config.generic.prettyName.stripLogs": "원목 벗기기",
+    "litematica-printer.config.generic.prettyName.printInAir": "공중에 프린트",
     "litematica-printer.config.hotkeys.comment.print": "이 키를 누르고 있는 동안 프린트가 진행됩니다.",
     "litematica-printer.config.hotkeys.comment.togglePrintingMode": "프린트 모드를 빠르게 켜고 끌 수 있습니다.",
     "litematica-printer.config.hotkeys.name.print": "프린트",

--- a/src/main/resources/assets/litematica-printer/lang/uk_ua.json
+++ b/src/main/resources/assets/litematica-printer/lang/uk_ua.json
@@ -1,5 +1,6 @@
 {
     "litematica-printer.config.generic.comment.interactBlocks": "Чи повинен друк установлювати стан блоку.",
+    "litematica-printer.config.generic.comment.printInAir": "Дозволяє розміщувати блоки в повітрі без необхідності підтримувальних блоків під ними.",
     "litematica-printer.config.generic.comment.printingDebug": "Вмикає журнал налагодження для друку.",
     "litematica-printer.config.generic.comment.printingInterval": "Інтервал друку. Менші значення означають більшу швидкість друку.\nЯкщо друк створює «блоки-привиди» або блоки спрямовані неправильно, збільште це значення.",
     "litematica-printer.config.generic.comment.printingMode": "Автоматична збірка/друк завантаженого вибору.\nЗверніть увагу, що деякі сервери та плаґіни для захисту від читів не дозволяють друкувати.",
@@ -13,6 +14,7 @@
     "litematica-printer.config.generic.name.printingRange": "printingRange",
     "litematica-printer.config.generic.name.replaceFluidSourceBlocks": "replaceFluidSourceBlocks",
     "litematica-printer.config.generic.name.stripLogs": "stripLogs",
+    "litematica-printer.config.generic.name.printInAir": "printInAir",
     "litematica-printer.config.generic.prettyName.interactBlocks": "Взаємодія з блоками",
     "litematica-printer.config.generic.prettyName.printingDebug": "Налагодження друку",
     "litematica-printer.config.generic.prettyName.printingInterval": "Інтервал друку",
@@ -20,6 +22,7 @@
     "litematica-printer.config.generic.prettyName.printingRange": "Діапазон друку",
     "litematica-printer.config.generic.prettyName.replaceFluidSourceBlocks": "Замінити блоки джерела рідини",
     "litematica-printer.config.generic.prettyName.stripLogs": "Обтесані колоди",
+    "litematica-printer.config.generic.prettyName.printInAir": "Друк в повітрі",
     "litematica-printer.config.hotkeys.comment.print": "Друкує під час натискання.",
     "litematica-printer.config.hotkeys.comment.togglePrintingMode": "Дозволяє швидко вмикати/вимикати режим друку.",
     "litematica-printer.config.hotkeys.name.print": "print",

--- a/src/main/resources/assets/litematica-printer/lang/zh_cn.json
+++ b/src/main/resources/assets/litematica-printer/lang/zh_cn.json
@@ -1,5 +1,6 @@
 {
     "litematica-printer.config.generic.comment.interactBlocks": "是否自动设置方块状态（如开关、方向等）。",
+    "litematica-printer.config.generic.comment.printInAir": "允许方块在空中放置，无需在下方提供支撑方块。",
     "litematica-printer.config.generic.comment.printingDebug": "开启投影打印机调试日志。",
     "litematica-printer.config.generic.comment.printingInterval": "打印间隔（单位：刻）。数值越低打印速度越快。\n如果出现\"幽灵方块\"或方块朝向错误，请提高此数值。",
     "litematica-printer.config.generic.comment.printingMode": "自动建造/打印已加载的选区\n请注意某些服务器和反作弊插件可能禁止自动打印功能。",
@@ -13,6 +14,7 @@
     "litematica-printer.config.generic.name.printingRange": "打印 - 范围",
     "litematica-printer.config.generic.name.replaceFluidSourceBlocks": "打印 - 替换流体源方块",
     "litematica-printer.config.generic.name.stripLogs": "打印 - 原木剥皮",
+    "litematica-printer.config.generic.name.printInAir": "打印 - 空中建造",
     "litematica-printer.config.generic.prettyName.interactBlocks": "方块交互",
     "litematica-printer.config.generic.prettyName.printingDebug": "打印调试模式",
     "litematica-printer.config.generic.prettyName.printingInterval": "打印间隔",
@@ -20,6 +22,7 @@
     "litematica-printer.config.generic.prettyName.printingRange": "打印范围",
     "litematica-printer.config.generic.prettyName.replaceFluidSourceBlocks": "替换流体源方块",
     "litematica-printer.config.generic.prettyName.stripLogs": "原木剥皮",
+    "litematica-printer.config.generic.prettyName.printInAir": "空中建造",
     "litematica-printer.config.hotkeys.comment.print": "按住按键时持续打印",
     "litematica-printer.config.hotkeys.comment.togglePrintingMode": "快速切换打印模式的开关状态",
     "litematica-printer.config.hotkeys.name.print": "打印",

--- a/src/main/resources/assets/litematica-printer/lang/zh_tw.json
+++ b/src/main/resources/assets/litematica-printer/lang/zh_tw.json
@@ -1,5 +1,6 @@
 {
     "litematica-printer.config.generic.comment.interactBlocks": "是否自動設定方塊狀態（如開關、方向等）。",
+    "litematica-printer.config.generic.comment.printInAir": "允許方塊在空中放置，無需在下方提供支撐方塊。",
     "litematica-printer.config.generic.comment.printingDebug": "開啟投影列印機除錯日誌。",
     "litematica-printer.config.generic.comment.printingInterval": "列印間隔（單位：tick）。數值越低列印速度越快。\n如果出現\"幽靈方塊\"或方塊朝向錯誤，請提高此數值。",
     "litematica-printer.config.generic.comment.printingMode": "自動建造/列印已載入的選區\n請注意某些伺服器和反作弊插件可能禁止自動列印功能。",
@@ -13,6 +14,7 @@
     "litematica-printer.config.generic.name.printingRange": "列印 - 範圍",
     "litematica-printer.config.generic.name.replaceFluidSourceBlocks": "列印 - 替換流體源方塊",
     "litematica-printer.config.generic.name.stripLogs": "列印 - 原木剝皮",
+    "litematica-printer.config.generic.name.printInAir": "列印 - 空中建造",
     "litematica-printer.config.generic.prettyName.interactBlocks": "方塊交互",
     "litematica-printer.config.generic.prettyName.printingDebug": "列印除錯模式",
     "litematica-printer.config.generic.prettyName.printingInterval": "列印間隔",
@@ -20,6 +22,7 @@
     "litematica-printer.config.generic.prettyName.printingRange": "列印範圍",
     "litematica-printer.config.generic.prettyName.replaceFluidSourceBlocks": "替換流體源方塊",
     "litematica-printer.config.generic.prettyName.stripLogs": "原木剝皮",
+    "litematica-printer.config.generic.prettyName.printInAir": "空中建造",
     "litematica-printer.config.hotkeys.comment.print": "按住按鍵時持續列印",
     "litematica-printer.config.hotkeys.comment.togglePrintingMode": "快速切換列印模式的開關狀態",
     "litematica-printer.config.hotkeys.name.print": "列印",


### PR DESCRIPTION
**Changes:**

-   Added PRINT_IN_AIR boolean config option to Configs.java
-   Modified GeneralPlacementGuide.getValidSide() to return a valid direction when air placement is enabled
-   Updated GeneralPlacementGuide.getHitVector() to target the center of the target position when air placement is enabled
-   Modified GeneralPlacementGuide.getPlacementContext() to create a BlockHitResult targeting the block position directly instead of an adjacent block
-   Updated GuesserGuide.getPlacementContext() to first attempt air placement before falling back to traditional placement methods
-   Added language translations for the new config option in all supported languages (not verified)

  Implementation Details:
  The changes follow the same principle as Litematica's EasyPlace feature. Instead of requiring an adjacent
  non-replaceable block to click on, the placement context now targets the target block position directly with
  Vec3d.ofCenter(state.blockPos). This allows blocks to be placed in air without adjacent support.