### PR TITLE
Port to 26.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("fabric-loom").version("1.15-SNAPSHOT")
+    id("net.fabricmc.fabric-loom").version("1.15-SNAPSHOT")
     id("maven-publish")
 }
 
@@ -20,8 +20,8 @@ val mod_version: String by project
 java {
     withSourcesJar()
 
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 repositories {
@@ -37,11 +37,10 @@ repositories {
 dependencies {
     minecraft("com.mojang:minecraft:${minecraft_version}")
 //    mappings("net.fabricmc:yarn:${mappings_version}:v2")
-    mappings(loom.officialMojangMappings())
     implementation("com.google.code.findbugs:jsr305:3.0.2")
 
-    modImplementation("net.fabricmc:fabric-loader:${fabric_loader_version}")
-    modImplementation("net.fabricmc.fabric-api:fabric-api:${fabric_api_version}")
+    implementation("net.fabricmc:fabric-loader:${fabric_loader_version}")
+    implementation("net.fabricmc.fabric-api:fabric-api:${fabric_api_version}")
     //modImplementation("curse.maven:litematica-${litematica_projectid}:${litematica_fileid}")
 
     // Masa's Maven
@@ -49,11 +48,11 @@ dependencies {
 //    modImplementation("fi.dy.masa.litematica:litematica-fabric-${minecraft_version_out}:${litematica_version}")
 
     // Sakura's Jitpack
-    modImplementation("com.github.sakura-ryoko:malilib:${malilib_version}")
-    modImplementation("com.github.sakura-ryoko:litematica:${litematica_version}")
+    implementation("com.github.sakura-ryoko:malilib:${malilib_version}")
+    implementation("com.github.sakura-ryoko:litematica:${litematica_version}")
 
     // For Mod Menu display
-    modCompileOnly("com.terraformersmc:modmenu:${mod_menu_version}")
+    compileOnly("com.terraformersmc:modmenu:${mod_menu_version}")
 //    modRuntimeOnly("me.fallenbreath:mixin-auditor:0.1.0")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,21 +3,20 @@ org.gradle.jvmargs = -Xmx2G
 org.gradle.parallel = false
 
 # Mod Properties
-mod_version = 3.2.1B
+mod_version = 3.2.19
 
 mod_id = litematica-printer
 maven_group = me.aleksilassila
 archives_base_name = litematica-printer
 
 # Dependencies (malilib / litematica)
-malilib_version = 1.21.11-0.27.6
-litematica_version = 1.21.11-0.26.0
+malilib_version = 26.1-0.28.1
+litematica_version = 26.1-0.27.0
 
 # Minecraft, Fabric Loader and API and mappings versions
-minecraft_version_out = 1.21.11
-minecraft_version = 1.21.11
-mappings_version = 1.21.11+build.1
+minecraft_version_out = 26.1
+minecraft_version = 26.1
 
-fabric_loader_version = 0.18.4
-mod_menu_version = 17.0.0-beta.2
-fabric_api_version = 0.141.3+1.21.11
+fabric_loader_version = 0.18.5
+mod_menu_version = 18.0.0-alpha.8
+fabric_api_version = 0.144.3+26.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/me/aleksilassila/litematica/printer/guides/Guides.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guides/Guides.java
@@ -22,8 +22,8 @@ public class Guides {
         registerGuide(RotatingBlockGuide.class, AbstractSkullBlock.class, SignBlock.class, AbstractBannerBlock.class);
         registerGuide(SlabGuide.class, SlabBlock.class);
         registerGuide(TorchGuide.class, TorchBlock.class);
-        registerGuide(FarmlandGuide.class, FarmBlock.class);
-        registerGuide(TillingGuide.class, FarmBlock.class);
+        registerGuide(FarmlandGuide.class, FarmlandBlock.class);
+        registerGuide(TillingGuide.class, FarmlandBlock.class);
         registerGuide(RailGuesserGuide.class, BaseRailBlock.class);
         registerGuide(ChestGuide.class, ChestBlock.class);
         registerGuide(FlowerPotGuide.class, FlowerPotBlock.class);

--- a/src/main/java/me/aleksilassila/litematica/printer/implementation/mixin/MixinClientPlayerEntity.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/implementation/mixin/MixinClientPlayerEntity.java
@@ -74,7 +74,7 @@ public class MixinClientPlayerEntity extends AbstractClientPlayer {
             Printer.printDebug("Current version: [{}], detected version [{}]", version, newVersion);
 
             if (!version.equals(newVersion)) {
-                minecraft.gui.getChat().addMessage(Component.literal("New version of Litematica Printer available in https://github.com/aleksilassila/litematica-printer/releases"));
+                minecraft.gui.getChat().addClientSystemMessage(Component.literal("New version of Litematica Printer available in https://github.com/aleksilassila/litematica-printer/releases"));
             }
         }).start();
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,11 +24,11 @@
     "litematica-printer-implementation.mixins.json"
   ],
   "depends": {
-    "fabric": "*",
-    "java": ">=21",
-    "minecraft": "1.21.11",
-    "malilib": ">=0.27.0- <0.28.0-",
-    "litematica": ">=0.25.0- <0.27.0-"
+    "fabric-api": "*",
+    "java": ">=25",
+    "minecraft": ">26",
+    "malilib": ">=0.28.0- <0.29.0-",
+    "litematica": ">=0.27.0- <0.28.0-"
   },
   "breaks": {
     "malilib": "<0.27.3-",


### PR DESCRIPTION
After all your mega hard work updating Litematica, porting Printer seems to have been fairly straightforward.

I'm guessing you don't want to merge this into LTS/1.21.11, so once you've had a chance to review, let me know if you'd like me to close this PR and reopen it into another destination.

## Validation Performed

I was able to toggle easy-place and printer modes and begin "printing" a schematic in one of my test worlds.