### PR TITLE
Port Litematica Printer to Minecraft 26.2-snapshot-5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 repositories {
+	mavenLocal()
 	maven {url = "https://masa.dy.fi/maven/sakura-ryoko"
 		content {includeGroupAndSubgroups("fi.dy.masa")}
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,13 +13,13 @@ mod_file_name = litematica-printer
 mod_version = 3.2.2
 
 # Dependencies (malilib / litematica)
-malilib_version = 0.28.2
-litematica_version = 0.27.1
+malilib_version = 0.28.3+26.2-snapshot-5
+litematica_version = 0.27.2
 
 # Minecraft, Fabric Loader and API and mappings versions
-minecraft_version_out = 26.1.1
-minecraft_version = 26.1.1
+minecraft_version_out = 26.2-snapshot-5
+minecraft_version = 26.2-snapshot-5
 
-fabric_loader_version = 0.18.6
+fabric_loader_version = 0.19.2
 mod_menu_version = 18.0.0-alpha.8
-fabric_api_version = 0.145.3+26.1.1
+fabric_api_version = 0.147.1+26.2

--- a/src/main/java/me/aleksilassila/litematica/printer/ActionHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/ActionHandler.java
@@ -33,9 +33,11 @@ public class ActionHandler {
         Action nextAction = actionQueue.poll();
 
         if (nextAction != null) {
+            PlacementDebug.log("action tick send action={} queueSizeAfterPoll={}", nextAction.getClass().getSimpleName(), actionQueue.size());
             Printer.printDebug("Sending action {}", nextAction);
             nextAction.send(client, player);
         } else {
+            PlacementDebug.log("action tick empty queueSize=0");
             lookAction = null;
         }
     }
@@ -44,8 +46,15 @@ public class ActionHandler {
         return actionQueue.isEmpty();
     }
 
+    public int getQueueSize() {
+        return actionQueue.size();
+    }
+
     public void addActions(Action... actions) {
+        PlacementDebug.log("actions addActions called count={} acceptsActions={} queueSizeBefore={}",
+                actions.length, acceptsActions(), actionQueue.size());
         if (!acceptsActions()) {
+            PlacementDebug.log("actions addActions ignored reason=queue-not-empty queueSize={}", actionQueue.size());
             return;
         }
 
@@ -56,5 +65,6 @@ public class ActionHandler {
         }
 
         actionQueue.addAll(List.of(actions));
+        PlacementDebug.log("actions addActions queued count={} queueSizeAfter={}", actions.length, actionQueue.size());
     }
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/PlacementDebug.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/PlacementDebug.java
@@ -1,0 +1,68 @@
+package me.aleksilassila.litematica.printer;
+
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.ItemStack;
+
+public final class PlacementDebug {
+    private static final boolean ENABLED = Boolean.getBoolean("litematica_printer.debugPlacement");
+    private static final int MAX_LINES_PER_SECOND = 80;
+    private static long windowStartMillis = System.currentTimeMillis();
+    private static int windowLineCount = 0;
+    private static int suppressedLineCount = 0;
+
+    private PlacementDebug() {
+    }
+
+    public static boolean enabled() {
+        return ENABLED;
+    }
+
+    public static void log(String message, Object... args) {
+        if (ENABLED) {
+            long now = System.currentTimeMillis();
+            if (now - windowStartMillis >= 1000) {
+                if (suppressedLineCount > 0) {
+                    Printer.logger.info("[placement] suppressed {} debug lines in previous second", suppressedLineCount);
+                }
+                windowStartMillis = now;
+                windowLineCount = 0;
+                suppressedLineCount = 0;
+            }
+            if (windowLineCount++ >= MAX_LINES_PER_SECOND) {
+                suppressedLineCount++;
+                return;
+            }
+            Printer.logger.info("[placement] " + message, args);
+        }
+    }
+
+    public static String stack(ItemStack stack) {
+        if (stack == null) {
+            return "null";
+        }
+        if (stack.isEmpty()) {
+            return "empty";
+        }
+        return stack.getCount() + "x" + stack.getItem();
+    }
+
+    public static String inventoryLocation(LocalPlayer player, ItemStack stack) {
+        if (player.getAbilities().instabuild) {
+            return "creative";
+        }
+        Inventory inventory = player.getInventory();
+        for (int i = 0; i < inventory.getNonEquipmentItems().size(); ++i) {
+            ItemStack inventoryStack = inventory.getNonEquipmentItems().get(i);
+            if (!inventoryStack.isEmpty() && ItemStack.isSameItem(inventoryStack, stack)) {
+                return Inventory.isHotbarSlot(i) ? "hotbar:" + i : "inventory:" + i;
+            }
+        }
+        return "missing";
+    }
+
+    public static String pos(BlockPos pos) {
+        return pos == null ? "null" : pos.toShortString();
+    }
+}

--- a/src/main/java/me/aleksilassila/litematica/printer/Printer.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/Printer.java
@@ -37,51 +37,104 @@ public class Printer {
 
     public boolean onGameTick() {
         WorldSchematic worldSchematic = SchematicWorldHandler.getSchematicWorld();
+        boolean printMode = Configs.PRINT_MODE.getBooleanValue();
+        boolean printPressed = Hotkeys.PRINT.getKeybind().isPressed();
+        boolean acceptsActions = actionHandler.acceptsActions();
+        boolean mayBuild = player.getAbilities().mayBuild;
+        boolean interactBlocks = Configs.INTERACT_BLOCKS.getBooleanValue();
 
-        if (!actionHandler.acceptsActions()) {
+        int reachableCount = 0;
+        int candidateCount = 0;
+        int mismatchCount = 0;
+        int guidesCount = 0;
+        int canExecuteTrueCount = 0;
+        int skippedByGuideCount = 0;
+        int actionBatchesQueued = 0;
+
+        if (!acceptsActions) {
+            PlacementDebug.log("tick gated acceptsActions=false printMode={} printPressed={} mayBuild={} worldSchematicNull={} queueSize={}",
+                    printMode, printPressed, mayBuild, worldSchematic == null, actionHandler.getQueueSize());
             return false;
         }
 
         if (worldSchematic == null) {
+            PlacementDebug.log("tick gated worldSchematicNull=true printMode={} printPressed={} mayBuild={} acceptsActions={}",
+                    printMode, printPressed, mayBuild, acceptsActions);
             return false;
         }
 
-        if (!Configs.PRINT_MODE.getBooleanValue() && !Hotkeys.PRINT.getKeybind().isPressed()) {
+        if (!printMode && !printPressed) {
+            PlacementDebug.log("tick gated printDisabled printMode={} printPressed={} mayBuild={} acceptsActions={} worldSchematicNull=false",
+                    printMode, printPressed, mayBuild, acceptsActions);
             return false;
         }
 
         Abilities abilities = player.getAbilities();
         if (!abilities.mayBuild) {
+            PlacementDebug.log("tick gated mayBuild=false printMode={} printPressed={} acceptsActions={} worldSchematicNull=false",
+                    printMode, printPressed, acceptsActions);
             return false;
         }
 
         List<BlockPos> positions = getReachablePositions();
+        reachableCount = positions.size();
         findBlock:
         for (BlockPos position : positions) {
+            candidateCount++;
             SchematicBlockState state = new SchematicBlockState(player.level(), worldSchematic, position);
             if (state.targetState.equals(state.currentState) || state.targetState.isAir()) {
                 continue;
             }
+            mismatchCount++;
+            PlacementDebug.log("candidate pos={} target={} current={}",
+                    PlacementDebug.pos(position), state.targetState, state.currentState);
 
             Guide[] guides = interactionGuides.getInteractionGuides(state);
+            guidesCount += guides.length;
+            PlacementDebug.log("candidate guides pos={} count={}", PlacementDebug.pos(position), guides.length);
 
             BlockHitResult result = RayTraceUtils.traceToSchematicWorld(player, 10, true, true);
             boolean isCurrentlyLookingSchematic = result != null && result.getBlockPos().equals(position);
+            PlacementDebug.log("candidate look pos={} lookingSchematic={} tracePos={}",
+                    PlacementDebug.pos(position), isCurrentlyLookingSchematic,
+                    result == null ? "null" : PlacementDebug.pos(result.getBlockPos()));
 
             for (Guide guide : guides) {
                 // Add INTERACT_BLOCKS pull by DarkReaper231
-                if (guide.canExecute(player) && Configs.INTERACT_BLOCKS.getBooleanValue()) {
+                boolean canExecute = guide.canExecute(player);
+                if (canExecute) {
+                    canExecuteTrueCount++;
+                }
+                PlacementDebug.log("guide decision pos={} guide={} canExecute={} interactBlocks={}",
+                        PlacementDebug.pos(position), guide.getClass().getSimpleName(), canExecute, interactBlocks);
+                if (canExecute && interactBlocks) {
                     printDebug("Executing {} for {}", guide, state);
                     List<Action> actions = guide.execute(player);
+                    PlacementDebug.log("guide actions pos={} guide={} actionCount={}",
+                            PlacementDebug.pos(position), guide.getClass().getSimpleName(), actions.size());
                     actionHandler.addActions(actions.toArray(Action[]::new));
+                    actionBatchesQueued++;
+                    PlacementDebug.log("tick queued reachable={} checked={} mismatches={} guides={} canExecuteTrue={} skippedByGuide={} actionBatches={} queueSize={}",
+                            reachableCount, candidateCount, mismatchCount, guidesCount, canExecuteTrueCount, skippedByGuideCount,
+                            actionBatchesQueued, actionHandler.getQueueSize());
                     return true;
                 }
+                if (canExecute && !interactBlocks) {
+                    PlacementDebug.log("guide blockedByConfig pos={} guide={} reason=INTERACT_BLOCKS false",
+                            PlacementDebug.pos(position), guide.getClass().getSimpleName());
+                }
                 if (guide.skipOtherGuides()) {
+                    skippedByGuideCount++;
+                    PlacementDebug.log("guide skipOtherGuides pos={} guide={}",
+                            PlacementDebug.pos(position), guide.getClass().getSimpleName());
                     continue findBlock;
                 }
             }
         }
 
+        PlacementDebug.log("tick done reachable={} checked={} mismatches={} guides={} canExecuteTrue={} skippedByGuide={} actionBatches={} queueSize={} printMode={} printPressed={} mayBuild={} acceptsActions={} worldSchematicNull=false",
+                reachableCount, candidateCount, mismatchCount, guidesCount, canExecuteTrueCount, skippedByGuideCount,
+                actionBatchesQueued, actionHandler.getQueueSize(), printMode, printPressed, mayBuild, acceptsActions);
         return false;
     }
 

--- a/src/main/java/me/aleksilassila/litematica/printer/actions/InteractAction.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/actions/InteractAction.java
@@ -1,6 +1,7 @@
 package me.aleksilassila.litematica.printer.actions;
 
 import me.aleksilassila.litematica.printer.Printer;
+import me.aleksilassila.litematica.printer.PlacementDebug;
 import me.aleksilassila.litematica.printer.implementation.PrinterPlacementContext;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
@@ -18,7 +19,14 @@ abstract public class InteractAction extends Action {
 
     @Override
     public void send(Minecraft client, LocalPlayer player) {
+        PlacementDebug.log("interact send begin pos={} hitBlock={} side={} hit={} hand={} selectedSlot={} selectedItem={} beforeState={}",
+                PlacementDebug.pos(context.getClickedPos()), PlacementDebug.pos(context.hitResult.getBlockPos()),
+                context.hitResult.getDirection(), context.hitResult.getLocation(), InteractionHand.MAIN_HAND,
+                player.getInventory().getSelectedSlot(), PlacementDebug.stack(player.getMainHandItem()),
+                player.level().getBlockState(context.getClickedPos()));
         interact(client, player, InteractionHand.MAIN_HAND, context.hitResult);
+        PlacementDebug.log("interact send after pos={} afterState={}",
+                PlacementDebug.pos(context.getClickedPos()), player.level().getBlockState(context.getClickedPos()));
         Printer.printDebug("InteractAction.send: Blockpos: {} Side: {} HitPos: {}", context.getClickedPos(), context.getClickedFace(), context.getClickLocation());
     }
 

--- a/src/main/java/me/aleksilassila/litematica/printer/actions/PrepareAction.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/actions/PrepareAction.java
@@ -1,6 +1,7 @@
 package me.aleksilassila.litematica.printer.actions;
 
 import me.aleksilassila.litematica.printer.Printer;
+import me.aleksilassila.litematica.printer.PlacementDebug;
 import me.aleksilassila.litematica.printer.config.Configs;
 import me.aleksilassila.litematica.printer.implementation.PrinterPlacementContext;
 import net.minecraft.client.Minecraft;
@@ -54,6 +55,11 @@ public class PrepareAction extends Action {
         ItemStack itemStack = context.getItemInHand();
         int slot = context.requiredItemSlot;
 
+        PlacementDebug.log("prepare begin targetPos={} requiredSlot={} requiredItem={} selectedSlot={} selectedItem={} instabuild={} shouldSneak={} rotate={} yaw={} pitch={}",
+                PlacementDebug.pos(context.getClickedPos()), slot, PlacementDebug.stack(itemStack),
+                player.getInventory().getSelectedSlot(), PlacementDebug.stack(player.getMainHandItem()),
+                player.getAbilities().instabuild, context.shouldSneak, Configs.ROTATE.getBooleanValue(), yaw, pitch);
+
         if (itemStack != null && !itemStack.isEmpty() && client.gameMode != null) {
             Printer.printDebug("PrepareAction#send(): slot [{}] // itemStack [{}]", slot, itemStack.toString());
             // This thing is straight from MinecraftClient#doItemPick()
@@ -62,15 +68,24 @@ public class PrepareAction extends Action {
             if (player.getAbilities().instabuild) {
                 this.addPickBlock(inventory, itemStack);
                 client.gameMode.handleCreativeModeItemAdd(player.getItemInHand(InteractionHand.MAIN_HAND), 36 + inventory.getSelectedSlot());
+                PlacementDebug.log("prepare creative selectedSlot={} selectedItem={} sentCreativeAddSlot={}",
+                        inventory.getSelectedSlot(), PlacementDebug.stack(player.getMainHandItem()), 36 + inventory.getSelectedSlot());
             } else if (slot != -1) {
                 if (Inventory.isHotbarSlot(slot)) {
                     inventory.setSelectedSlot(slot);
+                    PlacementDebug.log("prepare survival selectedHotbarSlot={} selectedItem={}",
+                            slot, PlacementDebug.stack(player.getMainHandItem()));
                 } else {
                     // TODO --> test this (pickFromInventory has been REMOVED)
                     //client.interactionManager.pickFromInventory(slot);
                     InventoryUtils.setPickedItemToHand(slot, itemStack, client);
+                    PlacementDebug.log("prepare survival pickedInventorySlot={} selectedSlot={} selectedItem={}",
+                            slot, inventory.getSelectedSlot(), PlacementDebug.stack(player.getMainHandItem()));
                 }
             }
+        } else {
+            PlacementDebug.log("prepare skipped itemOrGameMode item={} gameModeNull={}",
+                    PlacementDebug.stack(itemStack), client.gameMode == null);
         }
 
         if (Configs.ROTATE.getBooleanValue()) {
@@ -82,15 +97,19 @@ public class PrepareAction extends Action {
                         pitch, player.onGround(), player.horizontalCollision);
 
                 player.connection.send(packet);
+                PlacementDebug.log("prepare rotate sent yaw={} pitch={} modifyYaw={} modifyPitch={}",
+                        yaw, pitch, modifyYaw, modifyPitch);
             }
         }
 
         if (context.shouldSneak) {
             player.input.keyPresses = new Input(player.input.keyPresses.forward(), player.input.keyPresses.backward(), player.input.keyPresses.left(), player.input.keyPresses.right(), player.input.keyPresses.jump(), true, player.input.keyPresses.sprint());
             player.connection.send(new ServerboundPlayerInputPacket(player.input.keyPresses));
+            PlacementDebug.log("prepare sneak sent=true");
         } else {
             player.input.keyPresses = new Input(player.input.keyPresses.forward(), player.input.keyPresses.backward(), player.input.keyPresses.left(), player.input.keyPresses.right(), player.input.keyPresses.jump(), false, player.input.keyPresses.sprint());
             player.connection.send(new ServerboundPlayerInputPacket(player.input.keyPresses));
+            PlacementDebug.log("prepare sneak sent=false");
         }
     }
 

--- a/src/main/java/me/aleksilassila/litematica/printer/actions/ReleaseShiftAction.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/actions/ReleaseShiftAction.java
@@ -4,11 +4,13 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.protocol.game.ServerboundPlayerInputPacket;
 import net.minecraft.world.entity.player.Input;
+import me.aleksilassila.litematica.printer.PlacementDebug;
 
 public class ReleaseShiftAction extends Action {
     @Override
     public void send(Minecraft client, LocalPlayer player) {
         player.input.keyPresses = new Input(player.input.keyPresses.forward(), player.input.keyPresses.backward(), player.input.keyPresses.left(), player.input.keyPresses.right(), player.input.keyPresses.jump(), false, player.input.keyPresses.sprint());
         player.connection.send(new ServerboundPlayerInputPacket(player.input.keyPresses));
+        PlacementDebug.log("releaseShift sent");
     }
 }

--- a/src/main/java/me/aleksilassila/litematica/printer/guides/Guide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guides/Guide.java
@@ -1,6 +1,7 @@
 package me.aleksilassila.litematica.printer.guides;
 
 import me.aleksilassila.litematica.printer.SchematicBlockState;
+import me.aleksilassila.litematica.printer.PlacementDebug;
 import me.aleksilassila.litematica.printer.actions.Action;
 import me.aleksilassila.litematica.printer.implementation.BlockHelperImpl;
 import net.minecraft.client.player.LocalPlayer;
@@ -26,7 +27,10 @@ abstract public class Guide extends BlockHelperImpl {
     }
 
     protected boolean playerHasRightItem(LocalPlayer player) {
-        return getRequiredItemStackSlot(player) != -1;
+        int slot = getRequiredItemStackSlot(player);
+        PlacementDebug.log("guide required target={} guide={} slot={} hasItem={}",
+                targetState, getClass().getSimpleName(), slot, slot != -1);
+        return slot != -1;
     }
 
     protected int getSlotWithItem(LocalPlayer player, ItemStack itemStack) {
@@ -55,13 +59,20 @@ abstract public class Guide extends BlockHelperImpl {
 
     public boolean canExecute(LocalPlayer player) {
         if (!playerHasRightItem(player)) {
+            PlacementDebug.log("guide canExecute false reason=missing-item guide={} target={} current={}",
+                    getClass().getSimpleName(), targetState, currentState);
             return false;
         }
 
         BlockState targetState = state.targetState;
         BlockState currentState = state.currentState;
 
-        return !statesEqual(targetState, currentState);
+        boolean mismatch = !statesEqual(targetState, currentState);
+        if (!mismatch) {
+            PlacementDebug.log("guide canExecute false reason=wrong-current-block-or-state-already-matches guide={} target={} current={}",
+                    getClass().getSimpleName(), targetState, currentState);
+        }
+        return mismatch;
     }
 
     abstract public @Nonnull List<Action> execute(LocalPlayer player);
@@ -74,6 +85,13 @@ abstract public class Guide extends BlockHelperImpl {
      */
     protected Optional<ItemStack> getRequiredItem(LocalPlayer player) {
         List<ItemStack> requiredItems = getRequiredItems();
+        if (PlacementDebug.enabled()) {
+            for (ItemStack requiredItem : requiredItems) {
+                PlacementDebug.log("guide requiredItem target={} guide={} item={} location={}",
+                        targetState, getClass().getSimpleName(), PlacementDebug.stack(requiredItem),
+                        PlacementDebug.inventoryLocation(player, requiredItem));
+            }
+        }
 
         for (ItemStack requiredItem : requiredItems) {
             if (player.getAbilities().instabuild) {

--- a/src/main/java/me/aleksilassila/litematica/printer/guides/Guides.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guides/Guides.java
@@ -5,15 +5,17 @@ import me.aleksilassila.litematica.printer.SchematicBlockState;
 import me.aleksilassila.litematica.printer.guides.interaction.*;
 import me.aleksilassila.litematica.printer.guides.placement.*;
 
-import net.minecraft.util.Tuple;
 import net.minecraft.world.level.block.*;
 
 public class Guides {
-    protected final static ArrayList<Tuple<Class<? extends Guide>, Class<? extends Block>[]>> guides = new ArrayList<>();
+    protected final static ArrayList<GuideRegistration> guides = new ArrayList<>();
+
+    private record GuideRegistration(Class<? extends Guide> guideClass, Class<? extends Block>[] blocks) {
+    }
 
     @SafeVarargs
     protected static void registerGuide(Class<? extends Guide> guideClass, Class<? extends Block>... blocks) {
-        guides.add(new Tuple<>(guideClass, blocks));
+        guides.add(new GuideRegistration(guideClass, blocks));
     }
 
     static {
@@ -57,26 +59,26 @@ public class Guides {
         registerGuide(GuesserGuide.class);
     }
 
-    public ArrayList<Tuple<Class<? extends Guide>, Class<? extends Block>[]>> getGuides() {
+    public ArrayList<GuideRegistration> getGuides() {
         return guides;
     }
 
     public Guide[] getInteractionGuides(SchematicBlockState state) {
-        ArrayList<Tuple<Class<? extends Guide>, Class<? extends Block>[]>> guides = getGuides();
+        ArrayList<GuideRegistration> guides = getGuides();
 
         ArrayList<Guide> applicableGuides = new ArrayList<>();
-        for (Tuple<Class<? extends Guide>, Class<? extends Block>[]> guidePair : guides) {
+        for (GuideRegistration guidePair : guides) {
             try {
-                if (guidePair.getB().length == 0) {
+                if (guidePair.blocks().length == 0) {
                     applicableGuides
-                            .add(guidePair.getA().getConstructor(SchematicBlockState.class).newInstance(state));
+                            .add(guidePair.guideClass().getConstructor(SchematicBlockState.class).newInstance(state));
                     continue;
                 }
 
-                for (Class<? extends Block> clazz : guidePair.getB()) {
+                for (Class<? extends Block> clazz : guidePair.blocks()) {
                     if (clazz.isInstance(state.targetState.getBlock())) {
                         applicableGuides
-                                .add(guidePair.getA().getConstructor(SchematicBlockState.class).newInstance(state));
+                                .add(guidePair.guideClass().getConstructor(SchematicBlockState.class).newInstance(state));
                     }
                 }
             } catch (Exception ignored) {

--- a/src/main/java/me/aleksilassila/litematica/printer/guides/placement/GeneralPlacementGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guides/placement/GeneralPlacementGuide.java
@@ -1,6 +1,7 @@
 package me.aleksilassila.litematica.printer.guides.placement;
 
 import me.aleksilassila.litematica.printer.Printer;
+import me.aleksilassila.litematica.printer.PlacementDebug;
 import me.aleksilassila.litematica.printer.SchematicBlockState;
 import me.aleksilassila.litematica.printer.config.Configs;
 import me.aleksilassila.litematica.printer.implementation.PrinterPlacementContext;
@@ -53,6 +54,8 @@ public class GeneralPlacementGuide extends PlacementGuide {
         List<Direction> sides = getPossibleSides();
 
         if (sides.isEmpty()) {
+            PlacementDebug.log("placement validSide none reason=block-specific-condition-fail-no-sides guide={} target={} pos={}",
+                    getClass().getSimpleName(), targetState, PlacementDebug.pos(state.blockPos));
             return Optional.empty();
         }
 
@@ -85,10 +88,19 @@ public class GeneralPlacementGuide extends PlacementGuide {
 
         for (Direction validSide : validSides) {
             if (!isInteractive(state.offset(validSide).currentState.getBlock())) {
+                PlacementDebug.log("placement validSide guide={} target={} pos={} side={} validSides={}",
+                        getClass().getSimpleName(), targetState, PlacementDebug.pos(state.blockPos), validSide, validSides);
                 return Optional.of(validSide);
             }
         }
 
+        if (validSides.isEmpty()) {
+            PlacementDebug.log("placement validSide none reason=no-support-block guide={} target={} pos={} printInAir={} requiresSupport={} possibleSides={}",
+                    getClass().getSimpleName(), targetState, PlacementDebug.pos(state.blockPos), printInAir, getRequiresSupport(), sides);
+        } else {
+            PlacementDebug.log("placement validSide interactive guide={} target={} pos={} side={} validSides={}",
+                    getClass().getSimpleName(), targetState, PlacementDebug.pos(state.blockPos), validSides.getFirst(), validSides);
+        }
         return validSides.isEmpty() ? Optional.empty() : Optional.of(validSides.getFirst());
     }
 
@@ -123,8 +135,12 @@ public class GeneralPlacementGuide extends PlacementGuide {
             Optional<ItemStack> requiredItem = getRequiredItem(player);
             int requiredSlot = getRequiredItemStackSlot(player);
 
-            if (validSide.isEmpty() || hitVec.isEmpty() || requiredItem.isEmpty() || requiredSlot == -1)
+            if (validSide.isEmpty() || hitVec.isEmpty() || requiredItem.isEmpty() || requiredSlot == -1) {
+                PlacementDebug.log("placement context null guide={} target={} pos={} validSide={} hitVecPresent={} requiredItemPresent={} requiredSlot={}",
+                        getClass().getSimpleName(), targetState, PlacementDebug.pos(state.blockPos), validSide.orElse(null),
+                        hitVec.isPresent(), requiredItem.isPresent(), requiredSlot);
                 return null;
+            }
 
             Optional<Direction> lookDirection = getLookDirection();
             boolean requiresShift = getUseShift(state);
@@ -160,10 +176,17 @@ public class GeneralPlacementGuide extends PlacementGuide {
                         state.blockPos.relative(validSide.get()), false);
             }
 
-            return new PrinterPlacementContext(player, blockHitResult, requiredItem.get(), requiredSlot,
+            PrinterPlacementContext context = new PrinterPlacementContext(player, blockHitResult, requiredItem.get(), requiredSlot,
                     lookDirection.orElse(null), requiresShift);
+            PlacementDebug.log("placement context guide={} target={} pos={} hitBlock={} side={} hit={} requiredItem={} requiredSlot={} lookDirection={} sneak={} printInAir={}",
+                    getClass().getSimpleName(), targetState, PlacementDebug.pos(state.blockPos),
+                    PlacementDebug.pos(blockHitResult.getBlockPos()), blockHitResult.getDirection(), blockHitResult.getLocation(),
+                    PlacementDebug.stack(requiredItem.get()), requiredSlot, lookDirection.orElse(null), requiresShift, printInAir);
+            return context;
         } catch (Exception e) {
             Printer.logger.error("getPlacementContext(): Exception caught: {}", e.getMessage());
+            PlacementDebug.log("placement context exception guide={} target={} pos={} error={}",
+                    getClass().getSimpleName(), targetState, PlacementDebug.pos(state.blockPos), e.toString());
             //e.printStackTrace();
             return null;
         }

--- a/src/main/java/me/aleksilassila/litematica/printer/guides/placement/PlacementGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guides/placement/PlacementGuide.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import me.aleksilassila.litematica.printer.Printer;
+import me.aleksilassila.litematica.printer.PlacementDebug;
 import me.aleksilassila.litematica.printer.SchematicBlockState;
 import me.aleksilassila.litematica.printer.actions.Action;
 import me.aleksilassila.litematica.printer.actions.PrepareAction;
@@ -61,7 +62,9 @@ abstract public class PlacementGuide extends Guide {
     @Override
     protected @Nonnull List<ItemStack> getRequiredItems() {
         Printer.printDebug("PlacementGuide#getRequiredItems() - target state [{}]", state.targetState.toString());
-        return Collections.singletonList(getBlockItem(state.targetState));
+        ItemStack stack = getBlockItem(state.targetState);
+        PlacementDebug.log("placement requiredItems target={} item={}", state.targetState, PlacementDebug.stack(stack));
+        return Collections.singletonList(stack);
     }
 
     abstract protected boolean getUseShift(SchematicBlockState state);
@@ -71,29 +74,58 @@ abstract public class PlacementGuide extends Guide {
 
     @Override
     public boolean canExecute(LocalPlayer player) {
-        if (!super.canExecute(player))
+        if (!super.canExecute(player)) {
             return false;
+        }
 
         List<ItemStack> requiredItems = getRequiredItems();
-        if (requiredItems.isEmpty() || requiredItems.stream().allMatch(i -> i.is(Items.AIR)))
+        if (requiredItems.isEmpty() || requiredItems.stream().allMatch(i -> i.is(Items.AIR))) {
+            PlacementDebug.log("placement canExecute false reason=missing-item-or-air-item guide={} target={} requiredItems={}",
+                    getClass().getSimpleName(), targetState, requiredItems);
             return false;
+        }
 
         BlockPlaceContext ctx = getPlacementContext(player);
-        if (ctx == null || !ctx.canPlace()) return false;
+        if (ctx == null) {
+            PlacementDebug.log("placement canExecute false reason=placement-context-fail guide={} target={} pos={}",
+                    getClass().getSimpleName(), targetState, PlacementDebug.pos(state.blockPos));
+            return false;
+        }
+        if (!ctx.canPlace()) {
+            PlacementDebug.log("placement canExecute false reason=wrong-current-block ctxCanPlace=false guide={} target={} current={} pos={} ctx={}",
+                    getClass().getSimpleName(), targetState, currentState, PlacementDebug.pos(state.blockPos), ctx);
+            return false;
+        }
 //        if (!state.currentState.getMaterial().isReplaceable()) return false;
         if (!Configs.REPLACE_FLUIDS_SOURCE_BLOCKS.getBooleanValue()
-                && getProperty(state.currentState, LiquidBlock.LEVEL).orElse(1) == 0)
+                && getProperty(state.currentState, LiquidBlock.LEVEL).orElse(1) == 0) {
+            PlacementDebug.log("placement canExecute false reason=block-specific-condition-fail-fluid-source guide={} target={} current={}",
+                    getClass().getSimpleName(), targetState, currentState);
             return false;
+        }
 
         BlockState resultState = getRequiredItemAsBlock(player)
                 .orElse(targetState.getBlock())
                 .getStateForPlacement(ctx);
 
         if (resultState != null) {
-            if (!resultState.canSurvive(state.world, state.blockPos))
+            if (!resultState.canSurvive(state.world, state.blockPos)) {
+                PlacementDebug.log("placement canExecute false reason=no-support-block guide={} target={} resultState={} pos={}",
+                        getClass().getSimpleName(), targetState, resultState, PlacementDebug.pos(state.blockPos));
                 return false;
-            return !(currentState.getBlock() instanceof LiquidBlock) || canPlaceInWater(resultState);
+            }
+            boolean canPlaceInWater = !(currentState.getBlock() instanceof LiquidBlock) || canPlaceInWater(resultState);
+            if (!canPlaceInWater) {
+                PlacementDebug.log("placement canExecute false reason=block-specific-condition-fail-water guide={} target={} resultState={} current={}",
+                        getClass().getSimpleName(), targetState, resultState, currentState);
+            } else {
+                PlacementDebug.log("placement canExecute true guide={} target={} current={} resultState={} ctx={}",
+                        getClass().getSimpleName(), targetState, currentState, resultState, ctx);
+            }
+            return canPlaceInWater;
         } else {
+            PlacementDebug.log("placement canExecute false reason=placement-context-fail-null-result-state guide={} target={} ctx={}",
+                    getClass().getSimpleName(), targetState, ctx);
             return false;
         }
     }
@@ -103,11 +135,17 @@ abstract public class PlacementGuide extends Guide {
         List<Action> actions = new ArrayList<>();
         PrinterPlacementContext ctx = getPlacementContext(player);
 
-        if (ctx == null) return actions;
+        if (ctx == null) {
+            PlacementDebug.log("placement execute no-actions reason=placement-context-fail guide={} target={} pos={}",
+                    getClass().getSimpleName(), targetState, PlacementDebug.pos(state.blockPos));
+            return actions;
+        }
         actions.add(new PrepareAction(ctx));
         actions.add(new InteractActionImpl(ctx));
         if (ctx.shouldSneak) actions.add(new ReleaseShiftAction());
 
+        PlacementDebug.log("placement execute actions guide={} target={} pos={} count={} ctx={}",
+                getClass().getSimpleName(), targetState, PlacementDebug.pos(state.blockPos), actions.size(), ctx);
         return actions;
     }
 

--- a/src/main/java/me/aleksilassila/litematica/printer/implementation/actions/InteractActionImpl.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/implementation/actions/InteractActionImpl.java
@@ -1,9 +1,11 @@
 package me.aleksilassila.litematica.printer.implementation.actions;
 
+import me.aleksilassila.litematica.printer.PlacementDebug;
 import me.aleksilassila.litematica.printer.actions.InteractAction;
 import me.aleksilassila.litematica.printer.implementation.PrinterPlacementContext;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.phys.BlockHitResult;
 
@@ -15,8 +17,15 @@ public class InteractActionImpl extends InteractAction {
     @Override
     protected void interact(Minecraft client, LocalPlayer player, InteractionHand hand, BlockHitResult hitResult) {
         if (client.gameMode != null) {
-            client.gameMode.useItemOn(player, hand, hitResult);
-            client.gameMode.useItem(player, hand);
+            InteractionResult useItemOnResult = client.gameMode.useItemOn(player, hand, hitResult);
+            PlacementDebug.log("interact useItemOn result={} hand={} hitBlock={} side={} hit={} selectedItem={}",
+                    useItemOnResult, hand, PlacementDebug.pos(hitResult.getBlockPos()), hitResult.getDirection(),
+                    hitResult.getLocation(), PlacementDebug.stack(player.getItemInHand(hand)));
+            InteractionResult useItemResult = client.gameMode.useItem(player, hand);
+            PlacementDebug.log("interact useItem result={} hand={} selectedItem={}",
+                    useItemResult, hand, PlacementDebug.stack(player.getItemInHand(hand)));
+        } else {
+            PlacementDebug.log("interact skipped reason=gameMode-null");
         }
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,12 +27,12 @@
   ],
 
   "depends": {
-    "minecraft": "~26.1-",
+    "minecraft": ">=26.2-alpha.5 <26.3-",
     "fabric-networking-api-v1": ">=6.3.0"
   },
   "breaks": {
-    "malilib": "<0.28.2-",
-    "litematica": "<0.27.1-"
+    "malilib": "<0.28.3-",
+    "litematica": "<0.27.2-"
   },
 
   "custom": {


### PR DESCRIPTION
This is a draft port of Litematica Printer to Minecraft **26.2-snapshot-5**.

This depends on matching 26.2 MaLiLib and Litematica draft PRs:
- MaLiLib PR: https://github.com/sakura-ryoko/malilib/pull/148
- Litematica PR: https://github.com/sakura-ryoko/litematica/pull/345

### Changes
- Updated build/version metadata for 26.2-snapshot-5
- Updated Fabric Loader / Fabric API / Minecraft dependency metadata
- Updated MaLilib dependency to 0.28.3+26.2-snapshot-5
- Updated Litematica dependency to 0.27.2
- Added mavenLocal() for local testing against the 26.2 MaLiLib/Litematica ports
- Replaced removed net.minecraft.util.Tuple usage with local GuideRegistration record
- Added gated placement diagnostics behind: -Dlitematica_printer.debugPlacement=true
- Placement diagnostics are disabled by default and rate-limited when enabled

### Known notes / limitations
Some redstone, powered, and directional block states may still mismatch after placement. The observed stop reasons are per-block/state related, such as:
- no-support-block
- placement-context-fail
- wrong-current-block ctxCanPlace=false
- final-state mismatch after placement

This does not currently look like a general 26.2 interaction failure, since simple blocks and several interactive/redstone-related blocks do place successfully. These remaining cases may be existing Printer guide/block-state limitations or may need seperate follow-up testing.

This is intentionally opened as a draft because it depends on the matching MaLiLib/Litematica 26.2 draft PRs and because 26.2-snapshot-5 is still a snapshot target.