### PR TITLE
Fix various printInAir bugs

### DIFF
--- a/src/main/java/me/aleksilassila/litematica/printer/Printer.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/Printer.java
@@ -59,6 +59,9 @@ public class Printer {
         findBlock:
         for (BlockPos position : positions) {
             SchematicBlockState state = new SchematicBlockState(player.level(), worldSchematic, position);
+            if (!state.targetState.isAir()) {
+                printDebug("Considering {} target={} current={}", position, state.targetState, state.currentState);
+            }
             if (state.targetState.equals(state.currentState) || state.targetState.isAir()) {
                 continue;
             }
@@ -71,7 +74,8 @@ public class Printer {
             for (Guide guide : guides) {
                 // Add INTERACT_BLOCKS pull by DarkReaper231
                 if (guide.canExecute(player) && Configs.INTERACT_BLOCKS.getBooleanValue()) {
-                    printDebug("Executing {} for {}", guide, state);
+                    printDebug("PLACING {} at {} via {}", state.targetState.getBlock(), position, guide.getClass().getSimpleName());
+                    printDebug("  targetState={} currentState={} isAir={}", state.targetState, state.currentState, state.targetState.isAir());
                     List<Action> actions = guide.execute(player);
                     actionHandler.addActions(actions.toArray(Action[]::new));
                     return true;

--- a/src/main/java/me/aleksilassila/litematica/printer/guides/placement/GeneralPlacementGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guides/placement/GeneralPlacementGuide.java
@@ -7,7 +7,6 @@ import me.aleksilassila.litematica.printer.implementation.PrinterPlacementContex
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.RotatedPillarBlock;
 import net.minecraft.world.level.block.SlabBlock;
 import net.minecraft.world.level.block.state.properties.SlabType;
 import net.minecraft.world.phys.BlockHitResult;
@@ -103,13 +102,6 @@ public class GeneralPlacementGuide extends PlacementGuide {
     }
 
     private Optional<Vec3> getHitVector(SchematicBlockState state) {
-        boolean printInAir = Configs.PRINT_IN_AIR.getBooleanValue();
-
-        if (printInAir && !getRequiresSupport()) {
-            // For air placement, target the center of the target block position
-            return Optional.of(Vec3.atCenterOf(state.blockPos));
-        }
-
         return getValidSide(state).map(side -> Vec3.atCenterOf(state.blockPos)
                 .add(Vec3.atLowerCornerOf(side.getUnitVec3i()).scale(0.5))
                 .add(getHitModifier(side)));
@@ -129,36 +121,8 @@ public class GeneralPlacementGuide extends PlacementGuide {
             Optional<Direction> lookDirection = getLookDirection();
             boolean requiresShift = getUseShift(state);
 
-            boolean printInAir = Configs.PRINT_IN_AIR.getBooleanValue();
-            BlockHitResult blockHitResult;
-
-            if (printInAir && !getRequiresSupport()) {
-                // For air placement, target the block position directly
-                // Use a hit side that allows the block to maintain its intended orientation
-                // The specific side depends on the block type and its intended orientation
-                Direction hitSide = validSide.get().getOpposite(); // Use the opposite of the valid side to maintain orientation
-
-                // For pillar blocks like logs, we need to be more specific about the hit side
-                if (targetState.hasProperty(RotatedPillarBlock.AXIS)) {
-                    // For pillar blocks, use a side perpendicular to the intended axis
-                    Direction.Axis axis = targetState.getValue(RotatedPillarBlock.AXIS);
-                    if (axis == Direction.Axis.Y) {
-                        hitSide = Direction.DOWN; // vertical log - hit from above
-                    } else if (axis == Direction.Axis.X) {
-                        hitSide = Direction.WEST; // horizontal log along X - hit from West/East side
-                    } else { // Z axis
-                        hitSide = Direction.NORTH; // horizontal log along Z - hit from North/South side
-                    }
-                } else {
-                    // For non-pillars, use DOWN as default to place normally
-                    hitSide = Direction.DOWN;
-                }
-
-                blockHitResult = new BlockHitResult(hitVec.get(), hitSide, state.blockPos, false);
-            } else {
-                blockHitResult = new BlockHitResult(hitVec.get(), validSide.get().getOpposite(),
-                        state.blockPos.relative(validSide.get()), false);
-            }
+            BlockHitResult blockHitResult = new BlockHitResult(hitVec.get(), validSide.get().getOpposite(),
+                    state.blockPos.relative(validSide.get()), false);
 
             return new PrinterPlacementContext(player, blockHitResult, requiredItem.get(), requiredSlot,
                     lookDirection.orElse(null), requiresShift);

--- a/src/main/java/me/aleksilassila/litematica/printer/guides/placement/GuesserGuide.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/guides/placement/GuesserGuide.java
@@ -1,5 +1,6 @@
 package me.aleksilassila.litematica.printer.guides.placement;
 
+import me.aleksilassila.litematica.printer.Printer;
 import me.aleksilassila.litematica.printer.SchematicBlockState;
 import me.aleksilassila.litematica.printer.config.Configs;
 import me.aleksilassila.litematica.printer.implementation.PrinterPlacementContext;
@@ -53,31 +54,7 @@ public class GuesserGuide extends GeneralPlacementGuide {
         if (contextCache != null && !Configs.PRINT_DEBUG.getBooleanValue())
             return contextCache;
 
-        // First, try air placement if enabled
         boolean printInAir = Configs.PRINT_IN_AIR.getBooleanValue();
-        if (printInAir && !getRequiresSupport()) {
-            ItemStack requiredItem = getRequiredItem(player).orElse(ItemStack.EMPTY);
-            int slot = getRequiredItemStackSlot(player);
-
-            if (slot != -1) {
-                // Try different directions to find a successful placement
-                for (Direction side : directionsToTry) {
-                    Vec3 hitVec = Vec3.atCenterOf(state.blockPos);
-                    BlockHitResult hitResult = new BlockHitResult(hitVec, side.getOpposite(), state.blockPos, false);
-
-                    boolean requiresShift = getRequiresExplicitShift() || isInteractive(state.world.getBlockState(state.blockPos.relative(side.getOpposite())).getBlock());
-                    PrinterPlacementContext context = new PrinterPlacementContext(player, hitResult, requiredItem, slot, null, requiresShift);
-                    BlockState result = getRequiredItemAsBlock(player)
-                            .orElse(targetState.getBlock())
-                            .getStateForPlacement(context);
-
-                    if (result != null && (statesEqual(result, targetState) || correctChestPlacement(targetState, result))) {
-                        contextCache = context;
-                        return context;
-                    }
-                }
-            }
-        }
 
         ItemStack requiredItem = getRequiredItem(player).orElse(ItemStack.EMPTY);
         int slot = getRequiredItemStackSlot(player);
@@ -91,8 +68,8 @@ public class GuesserGuide extends GeneralPlacementGuide {
                 BlockState neighborState = state.world.getBlockState(neighborPos);
                 boolean requiresShift = getRequiresExplicitShift() || isInteractive(neighborState.getBlock());
 
-                if (!canBeClicked(state.world, neighborPos) || // Handle unclickable grass for example
-                        neighborState.canBeReplaced())
+                if (!(printInAir && !getRequiresSupport()) && (!canBeClicked(state.world, neighborPos) ||
+                        neighborState.canBeReplaced()))
                     continue;
 
                 Vec3 hitVec = Vec3.atCenterOf(state.blockPos)
@@ -103,8 +80,9 @@ public class GuesserGuide extends GeneralPlacementGuide {
                     multiplier = new Vec3(multiplier.x == 0 ? 1 : 0, multiplier.y == 0 ? 1 : 0,
                             multiplier.z == 0 ? 1 : 0);
 
+                    BlockPos hitPos = (printInAir && !getRequiresSupport()) ? state.blockPos : neighborPos;
                     BlockHitResult hitResult = new BlockHitResult(hitVec.add(hitVecToTry.multiply(multiplier)),
-                            side.getOpposite(), neighborPos, false);
+                            side.getOpposite(), hitPos, false);
                     PrinterPlacementContext context = new PrinterPlacementContext(player, hitResult, requiredItem, slot,
                             lookDirection, requiresShift);
                     BlockState result = getRequiredItemAsBlock(player)
@@ -115,6 +93,8 @@ public class GuesserGuide extends GeneralPlacementGuide {
                     if (result != null
                             && (statesEqual(result, targetState) || correctChestPlacement(targetState, result))) {
                         contextCache = context;
+                        Printer.printDebug("Cached context: side={} neighbor={} lookDir={}",
+                                side, neighborPos, lookDirection);
                         return context;
                     }
                 }

--- a/src/main/java/me/aleksilassila/litematica/printer/mixin/GuiConfigsMixin.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/mixin/GuiConfigsMixin.java
@@ -21,8 +21,18 @@ public class GuiConfigsMixin {
         return Configs.getConfigList();
     }
 
+    @Redirect(method = "getAllConfigs", at = @At(value = "FIELD", target = "Lfi/dy/masa/litematica/config/Configs$Generic;OPTIONS:Lcom/google/common/collect/ImmutableList;", opcode = Opcodes.GETSTATIC))
+    private ImmutableList<IConfigBase> moreOptionsAll() {
+        return Configs.getConfigList();
+    }
+
     @Redirect(method = "getConfigs", at = @At(value = "FIELD", target = "Lfi/dy/masa/litematica/config/Hotkeys;HOTKEY_LIST:Ljava/util/List;", opcode = Opcodes.GETSTATIC))
     private List<ConfigHotkey> moreHotkeys() {
+        return Hotkeys.getHotkeyList();
+    }
+
+    @Redirect(method = "getAllConfigs", at = @At(value = "FIELD", target = "Lfi/dy/masa/litematica/config/Hotkeys;HOTKEY_LIST:Ljava/util/List;", opcode = Opcodes.GETSTATIC))
+    private List<ConfigHotkey> moreHotkeysAll() {
         return Hotkeys.getHotkeyList();
     }
 }


### PR DESCRIPTION
What the fixes do:

1. Stops the printer from placing blocks in the wrong spot — this was the main bug. When printInAir was on, blocks also ended up one block below the ones that needed to be placed, needing a support, and occasionally placing extra blocks when printing.
2. Makes printInAir work within the normal placement flow — the old implementation had air placement split off into separate logic that didn't interact well with the rest of the system. It's been folded into the standard placement code so it behaves the same way as normal placement, just without needing a support block.
3. Config options now show up in all the right places — custom printer settings and hotkeys were only appearing in one of Litematica's two config screens. Now they show up in both.
4. Better debug output — if you turn on debug logging, you'll see more useful info about what the printer is trying to place and where.